### PR TITLE
Improve mobile navigation accessibility

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -43,13 +43,15 @@ export default function Header() {
           className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:bg-slate-100 md:hidden"
           onClick={() => setMobileOpen((prev) => !prev)}
           aria-label="Toggle navigation"
+          aria-expanded={mobileOpen}
+          aria-controls="mobile-navigation"
         >
           {mobileOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
         </button>
       </div>
 
       {mobileOpen && (
-        <div className="border-t border-slate-200 bg-white md:hidden">
+        <div id="mobile-navigation" className="border-t border-slate-200 bg-white md:hidden">
           <nav className="space-y-1 px-4 py-4 text-base font-medium text-slate-700">
             {navigation.map((item) => (
               <a key={item.name} href={item.href} className="block rounded-md px-3 py-2 hover:bg-slate-100">


### PR DESCRIPTION
## Summary
- add aria-expanded and aria-controls to the mobile navigation toggle button
- assign an id to the collapsible menu container so assistive tech can associate the button and menu

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173
- Playwright accessibility check confirming aria-expanded state changes

------
https://chatgpt.com/codex/tasks/task_e_68dabdbb18f0832eb63b4be66593c5b2